### PR TITLE
DOC: Tweak ReleaseNotes.md, add v0.5.

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,11 @@
+These releases are referenced on the Github Releases page,  https://github.com/JakeGinnivan/GitReleaseNotes/releases
+
+# 0.5.0  a64439d    Jun 25, 2014 
+- 17 commits to master since this release
+- Fixed a bunch of small issues
+- For diffs see https://github.com/JakeGinnivan/GitReleaseNotes/compare/0.5.0...master
+
+
 # 0.4.0 (25 May 2014)
 
  - [#35](https://github.com/JakeGinnivan/GitReleaseNotes/pull/35) - When specifying 'FromTag all' the issues closed for the first tag aren't included contributed by Petrik van der Velde ([pvandervelde](https://github.com/pvandervelde))


### PR DESCRIPTION
1.v0.5 was missing so added url to see the diffs in code (didn't know about this before!) https://github.com/JakeGinnivan/GitReleaseNotes/compare/0.5.0...master 
1a.That path said that release notes for 0.5 were here but aren't.
2.I can add this url here per ticket  #61 , and I also wish we could add a reference back to this file from there. (I don't have privileges)