### PR TITLE
Support remote repo's

### DIFF
--- a/src/GitReleaseNotes.Tests/GitReleaseNotes.Tests.csproj
+++ b/src/GitReleaseNotes.Tests/GitReleaseNotes.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="ArgumentTests.cs" />
     <Compile Include="CommitGrouperTests.cs" />
     <Compile Include="CommitGrouperTestsMultipleTagsPerCommit.cs" />
+    <Compile Include="GitRemoteRepositoryTests.cs" />
     <Compile Include="IssueTrackers\GitHub\GitHubIssueTrackerTests.cs" />
     <Compile Include="IssueTrackers\GitHub\NetworkEx.cs" />
     <Compile Include="IssueTrackers\GitHub\RemoteCollectionEx.cs" />
@@ -83,6 +84,7 @@
     <Compile Include="ReleaseNotesGeneratorTests.cs" />
     <Compile Include="SemanticReleaseNotesTests.cs" />
     <Compile Include="TestDataCreator.cs" />
+    <Compile Include="TestGitRepoUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/GitReleaseNotes.Tests/GitRemoteRepositoryTests.cs
+++ b/src/GitReleaseNotes.Tests/GitRemoteRepositoryTests.cs
@@ -1,0 +1,154 @@
+﻿using GitReleaseNotes.Git;
+using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Extensions;
+
+namespace GitReleaseNotes.Tests
+{
+    public class GitRemoteRepositoryTests : ILog
+    {
+        public void WriteLine(string s)
+        {
+            Console.WriteLine(s);
+        }
+
+        [Fact]
+        public void CanGetRemoteRepoContext()
+        {
+            // Arrange
+            // 1. Create a local repo to serve as the source / origin for our clone.
+            var currentDir = Environment.CurrentDirectory;
+            var originRepoDir = TestGitRepoUtils.GetUniqueTempFolder("testOriginGitRepo");
+            var testOriginRepo = TestGitRepoUtils.CreateEmptyTestRepo(originRepoDir);
+            string expectedDefaultBranchName = "master";          
+
+            // Construct the arguments necessary for cloning the origin repo.
+            var remoteArgs = new GitReleaseNotes.Git.GitRemoteRepositoryContextFactory.RemoteRepoArgs();
+            var creds = new DefaultCredentials();
+            remoteArgs.Credentials = creds;
+            var desinationDirForClone = TestGitRepoUtils.GetUniqueTempFolder("testClonedGitRepo"); // Path.Combine(currentDir, "testClonedGitRepo", Guid.NewGuid().ToString("N"));
+            remoteArgs.DestinationPath = desinationDirForClone;          
+            remoteArgs.Url = testOriginRepo.Info.Path; // This could be the Url of the git repo, but as this is a unit test, we are using a local file path.
+          
+            ILog logger = this;           
+            var remoteRepoContextFactory = new GitRemoteRepositoryContextFactory(logger, remoteArgs);
+
+            // Act
+            using (var repoContext = remoteRepoContextFactory.GetRepositoryContext())
+            {
+                // Assert
+                Assert.True(repoContext.IsRemote);
+                Assert.True(Directory.Exists(Path.Combine(desinationDirForClone, ".git")));
+
+                var currentBranch = repoContext.Repository.Head.CanonicalName;
+                Assert.True(currentBranch.EndsWith(expectedDefaultBranchName)); // cloned repo should default to master branch.
+            }
+        }
+
+        [Theory]
+        [InlineData("master")]
+        [InlineData("feature/somefeature")]
+        public void CanGetRemoteRepoContextWithHeadAtBranchName(string branchName)
+        {
+            // Arrange
+            // Create a local repo to serve as the origin for our clone.
+
+            var originRepoDir = TestGitRepoUtils.GetUniqueTempFolder("testOriginGitRepo");
+            
+            //Path.Combine(currentDir, "", Guid.NewGuid().ToString("N"));
+
+            using(var testOriginRepo = TestGitRepoUtils.CreateRepoWithBranch(originRepoDir, branchName))
+            {
+                // Construct the arguments necessary for cloning this origin repo.
+                var remoteArgs = new GitReleaseNotes.Git.GitRemoteRepositoryContextFactory.RemoteRepoArgs();
+                var creds = new DefaultCredentials();
+                remoteArgs.Credentials = creds;
+
+                var desinationDirForClone = TestGitRepoUtils.GetUniqueTempFolder("testClonedGitRepo"); // Path.Combine(currentDir, "testClonedGitRepo", Guid.NewGuid().ToString("N"));
+                remoteArgs.DestinationPath = desinationDirForClone;
+               
+                remoteArgs.Url = testOriginRepo.Info.Path; // This could be the Url of the git repo, but as this is a unit test, we are using a local file path.
+                ILog logger = this;
+
+                // This is the sut.
+                var remoteRepoContextFactory = new GitRemoteRepositoryContextFactory(logger, remoteArgs);
+
+                using (var repoContext = remoteRepoContextFactory.GetRepositoryContext())
+                {
+                    // Act
+                    repoContext.PrepareRemoteRepoForUse(branchName);
+
+                    // The cloned repo should now be set to the specified branch name.
+                    var currentBranch = repoContext.Repository.Head.CanonicalName;
+                    Assert.True(currentBranch.EndsWith(branchName));
+                }
+            }       
+        }
+
+        [Theory]
+        [InlineData("master", true)]
+        [InlineData("feature/somefeature", false)]
+        public void CanGetRemoteRepoContextAndCheckoutReleaseNotesIfExists(string branchName, bool shouldHaveReleaseNotesFile)
+        {
+            // Arrange
+            // Create a local repo to serve as the origin for our clone, - with a release notes file.
+            var currentDir = Environment.CurrentDirectory;
+            var originRepoDir = TestGitRepoUtils.GetUniqueTempFolder("testOriginGitRepo");  
+
+            using (var testOriginRepo = TestGitRepoUtils.CreateRepoWithBranch(originRepoDir, branchName))
+            {
+                string releaseNotesFileName = Guid.NewGuid().ToString();
+                // If a release notes file should be added, switch to the branch and add one.
+                if (shouldHaveReleaseNotesFile)
+                {
+                    // switch head to the branch.
+                    var branchInfo = new GitBranchNameInfo(branchName);
+                    var targetBranchName = branchInfo.GetCanonicalBranchName();
+                    var newHead = testOriginRepo.Refs.FirstOrDefault(localRef => string.Equals(localRef.CanonicalName, targetBranchName));
+                    testOriginRepo.Refs.UpdateTarget(testOriginRepo.Refs.Head, newHead);
+
+                    // commit a releasenotes file to the branch.
+                    var releaseNotesFilePath = Path.Combine(testOriginRepo.Info.WorkingDirectory, releaseNotesFileName);
+                    File.WriteAllText(releaseNotesFilePath, @"Some customised release notes contents...");
+                    TestGitRepoUtils.CommitFile(testOriginRepo, releaseNotesFilePath, "Added test release notes file to repo");
+                }
+
+                // Construct the arguments necessary for cloning the origin repo.
+                var remoteArgs = new GitReleaseNotes.Git.GitRemoteRepositoryContextFactory.RemoteRepoArgs();
+                var creds = new DefaultCredentials();
+                remoteArgs.Credentials = creds;
+                var desinationDirForClone = TestGitRepoUtils.GetUniqueTempFolder("testClonedGitRepo"); // Path.Combine(currentDir, "testClonedGitRepo", Guid.NewGuid().ToString("N"));
+                remoteArgs.DestinationPath = desinationDirForClone;
+                remoteArgs.Url = testOriginRepo.Info.Path; // This could be the Url of the git repo, but as this is a unit test, we are using a local file path.
+                ILog logger = this;
+              
+                var remoteRepoContextFactory = new GitRemoteRepositoryContextFactory(logger, remoteArgs);
+                using (var repoContext = remoteRepoContextFactory.GetRepositoryContext())
+                {                    
+                    repoContext.PrepareRemoteRepoForUse(branchName);
+
+                    // Act.
+                    repoContext.CheckoutFilesIfExist(releaseNotesFileName);
+
+                    // Assert.
+                    var releaseNotesFilePath = Path.Combine(desinationDirForClone,releaseNotesFileName);
+                    Assert.Equal(shouldHaveReleaseNotesFile, File.Exists(releaseNotesFilePath));                    
+                }
+
+            }
+
+          
+        }
+
+
+       
+
+       
+    }
+}

--- a/src/GitReleaseNotes.Tests/TestGitRepoUtils.cs
+++ b/src/GitReleaseNotes.Tests/TestGitRepoUtils.cs
@@ -1,0 +1,78 @@
+﻿using GitReleaseNotes.Git;
+using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GitReleaseNotes.Tests
+{
+    public static class TestGitRepoUtils
+    {
+
+        public static string GetUniqueTempFolder(string parentFolderName)
+        {
+             var currentDir = Path.GetTempPath();   
+             var repoDir = Path.Combine(currentDir, parentFolderName, Guid.NewGuid().ToString("N"));
+             return repoDir;
+        }
+
+        public static IRepository CreateRepoWithBranch(string path, string branchName)
+        {
+            LibGit2Sharp.Repository.Init(path);
+            Console.WriteLine("Created git repository at '{0}'", path);
+                     
+            var repo = new Repository(path);          
+
+            // Let's move the HEAD to this branch to be created
+            var branchInfo = new GitBranchNameInfo(branchName);
+
+            repo.Refs.UpdateTarget("HEAD", branchInfo.GetCanonicalBranchName());
+            // Create a commit against HEAD
+            Commit c = GenerateCommit(repo);
+            var branch = repo.Branches[branchName];
+            if (branch == null)
+            {
+                Console.WriteLine("Branch was NULL!");
+            }
+            return repo;          
+           
+        }    
+
+        public static IRepository CreateEmptyTestRepo(string path)
+        {
+            LibGit2Sharp.Repository.Init(path);
+            Console.WriteLine("Created git repository at '{0}'", path);
+            return new Repository(path);
+        }
+       
+        public static Commit GenerateCommit(IRepository repository, string comment = null)
+        {
+            var randomFile = Path.Combine(repository.Info.WorkingDirectory, Guid.NewGuid().ToString());
+            File.WriteAllText(randomFile, string.Empty);
+            comment = comment ?? "Test generated commit.";
+            return CommitFile(repository, randomFile, comment);           
+        }
+        
+        public static Commit CommitFile(IRepository repo, string filePath, string comment)
+        {
+            repo.Stage(filePath);
+            return repo.Commit(comment, SignatureNow(), SignatureNow());
+        }
+
+        public static Signature SignatureNow()
+        {
+            var dateTimeOffset = DateTimeOffset.Now;
+            return Signature(dateTimeOffset);
+        }
+
+        public static Signature Signature(DateTimeOffset dateTimeOffset)
+        {
+            return new Signature("Billy", "billy@thesundancekid.com", dateTimeOffset);
+        }
+
+    }
+}

--- a/src/GitReleaseNotes.sln
+++ b/src/GitReleaseNotes.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitReleaseNotes", "GitReleaseNotes\GitReleaseNotes.csproj", "{61D661AC-DC68-4862-8830-FE730C9B15FE}"
 EndProject
@@ -9,7 +9,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{C79694
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config
 		.nuget\NuGet.exe = .nuget\NuGet.exe
-		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A1F62FBD-CDAC-45AF-A89F-898114F27337}"

--- a/src/GitReleaseNotes/Git/GitBranchNameInfo.cs
+++ b/src/GitReleaseNotes/Git/GitBranchNameInfo.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitReleaseNotes.Git
+{
+    /// <summary>
+    /// Responsible for providing information about a branch from it's name.
+    /// </summary>
+    public class GitBranchNameInfo
+    {
+        private string branchName;
+
+        public GitBranchNameInfo(string branchName)
+        {
+            this.branchName = branchName ?? string.Empty;
+        }
+
+        public string GetCanonicalBranchName()
+        {
+            if (IsPullRequest())
+            {
+                branchName = branchName.Replace("pull-requests", "pull");
+                branchName = branchName.Replace("pr", "pull");
+
+                return string.Format("refs/{0}/head", branchName);
+            }
+
+            return string.Format("refs/heads/{0}", branchName);
+        }
+
+        public bool IsPullRequest()
+        {
+            return branchName.Contains("pull/") || branchName.Contains("pull-requests/") || branchName.Contains("pr/");
+        }
+
+        public bool IsHotfix()
+        {
+            return branchName.StartsWith("hotfix-") || branchName.StartsWith("hotfix/");
+        }
+
+        public string GetHotfixSuffix()
+        {
+            var result = this.TrimStart(branchName, "hotfix-");
+            result = this.TrimStart(result, "hotfix/");
+            return result;
+        }
+
+        public bool IsRelease()
+        {
+            return branchName.StartsWith("release-") || branchName.StartsWith("release/");
+        }
+
+        public string GetReleaseSuffix()
+        {
+            var result = this.TrimStart(branchName, "release-");
+            result = this.TrimStart(result, "release/");
+            return result;
+        }
+
+        public string GetUnknownBranchSuffix()
+        {
+            var unknownBranchSuffix = branchName.Split('-', '/');
+            if (unknownBranchSuffix.Length == 1)
+                return branchName;
+            return unknownBranchSuffix[1];
+        }
+
+        public bool IsDevelop()
+        {
+            return branchName == "develop";
+        }
+
+        public bool IsMaster()
+        {
+            return branchName == "master";
+        }
+
+        public bool IsSupport()
+        {
+            return branchName.ToLower().StartsWith("support-") || branchName.ToLower().StartsWith("support/");
+        }
+
+        private string TrimStart(string value, string toTrim)
+        {
+            if (!value.StartsWith(toTrim, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return value;
+            }
+            var startIndex = toTrim.Length;
+            return value.Substring(startIndex);
+        }
+    }
+}

--- a/src/GitReleaseNotes/Git/GitLocalRepositoryContextFactory.cs
+++ b/src/GitReleaseNotes/Git/GitLocalRepositoryContextFactory.cs
@@ -1,0 +1,41 @@
+﻿using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitReleaseNotes.Git
+{ 
+
+    public class GitLocalRepositoryContextFactory : IGitRepositoryContextFactory
+    {
+        private ILog logger;
+        private string workingDir;
+
+        public GitLocalRepositoryContextFactory(ILog logger, string workingDir)
+        {
+            this.logger = logger;
+            this.workingDir = workingDir;
+        }
+
+        public GitRepositoryContext GetRepositoryContext()
+        {
+            // scan the working directory (default to current directory)
+            var gitDirectory = GitDirFinder.TreeWalkForGitDir(workingDir);
+            if (string.IsNullOrEmpty(gitDirectory))
+            {
+                throw new Exception("Failed to find a .git folder in the working directory.");
+            }
+
+            Console.WriteLine("Git directory found at {0}", gitDirectory);
+            var repositoryRoot = Directory.GetParent(gitDirectory).FullName;
+            var gitRepo = new Repository(gitDirectory);
+            var context = new GitRepositoryContext(gitRepo, logger, null, false, string.Empty);
+            return context;
+        }
+    }
+
+}
+

--- a/src/GitReleaseNotes/Git/GitRemoteRepositoryContextFactory.cs
+++ b/src/GitReleaseNotes/Git/GitRemoteRepositoryContextFactory.cs
@@ -26,10 +26,10 @@ namespace GitReleaseNotes.Git
 
             var gitRootDirectory = Path.Combine(args.DestinationPath);
             var gitDirectory = Path.Combine(gitRootDirectory, ".git");
-            if (Directory.Exists(gitRootDirectory))
+            if (Directory.Exists(gitDirectory))
             {
-                logger.WriteLine(string.Format("Deleting existing .git folder from '{0}' to force new checkout from url", gitRootDirectory));
-                DeleteGitDirectory(gitRootDirectory);
+                logger.WriteLine(string.Format("Deleting existing .git folder from '{0}' to force new checkout from url", gitDirectory));
+                DeleteGitDirectory(gitDirectory);
             }
 
             Credentials credentials = args.Credentials;            

--- a/src/GitReleaseNotes/Git/GitRemoteRepositoryContextFactory.cs
+++ b/src/GitReleaseNotes/Git/GitRemoteRepositoryContextFactory.cs
@@ -1,0 +1,95 @@
+﻿using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitReleaseNotes.Git
+{  
+
+    public class GitRemoteRepositoryContextFactory : IGitRepositoryContextFactory
+    {
+        private ILog logger;
+        private RemoteRepoArgs args;
+
+        public GitRemoteRepositoryContextFactory(ILog logger, RemoteRepoArgs args)
+        {
+            this.logger = logger;
+            this.args = args;
+        }
+
+        public GitRepositoryContext GetRepositoryContext()
+        {
+            args.Validate();
+
+            var gitRootDirectory = Path.Combine(args.DestinationPath);
+            var gitDirectory = Path.Combine(gitRootDirectory, ".git");
+            if (Directory.Exists(gitRootDirectory))
+            {
+                logger.WriteLine(string.Format("Deleting existing .git folder from '{0}' to force new checkout from url", gitRootDirectory));
+                DeleteGitDirectory(gitRootDirectory);
+            }
+
+            Credentials credentials = args.Credentials;            
+
+            logger.WriteLine(string.Format("Retrieving git info from url '{0}'", args.Url));
+
+            var cloneOptions = new CloneOptions();
+            cloneOptions.IsBare = true;
+            cloneOptions.Checkout = false;
+            cloneOptions.CredentialsProvider = (url, usernameFromUrl, types) => credentials;
+
+            var repoPath = Repository.Clone(args.Url, gitDirectory, cloneOptions);
+            var repository = new Repository(repoPath);
+            var repoContext = new GitRepositoryContext(repository, logger, credentials, true, args.Url);          
+            return repoContext;
+        }
+
+        /// <summary>
+        /// Deletes a .Git directory and all of it's contents.
+        /// </summary>
+        /// <param name="path"></param>
+        private static void DeleteGitDirectory(string path)
+        {
+            var directory = new DirectoryInfo(path) { Attributes = FileAttributes.Normal };
+            if (directory.Name != ".git")
+            {
+                throw new ArgumentException("Cannot delete a diretory that isn't a git repository.");
+            }
+            foreach (var info in directory.GetFileSystemInfos("*", SearchOption.AllDirectories))
+            {
+                info.Attributes = FileAttributes.Normal;
+            }
+            directory.Delete(true);
+        }
+
+        public class RemoteRepoArgs
+        {
+            public string DestinationPath { get; set; }
+            public string Url { get; set; }
+            public Credentials Credentials { get; set; }           
+
+            internal void Validate()
+            {
+                if (string.IsNullOrEmpty(Url))
+                {
+                    throw new ArgumentException("Url of git repository must be specified.");
+                }
+                if (string.IsNullOrEmpty(DestinationPath))
+                {
+                    throw new ArgumentException("DestinationPath to place the cloned repository must be specified.");
+                }
+            }
+
+            internal bool HasCredentials()
+            {
+                return Credentials != null;
+            }
+        }
+
+    }
+
+}
+

--- a/src/GitReleaseNotes/Git/GitRepositoryContext.cs
+++ b/src/GitReleaseNotes/Git/GitRepositoryContext.cs
@@ -1,0 +1,309 @@
+﻿using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitReleaseNotes.Git
+{
+    /// <summary>
+    /// Provides a useful wrapper around an <see cref="IRepository" instance. />
+    /// </summary>
+    public sealed class GitRepositoryContext : IDisposable
+    {
+        private IRepository repository;
+        private ILog logger;
+        private bool isRemote;
+        private Credentials credentials;
+        private string repoUrl;
+
+        public GitRepositoryContext(IRepository repository, ILog logger, Credentials credentials, bool isRemote, string repoUrl)
+        {
+            this.repository = repository;
+            this.logger = logger;
+            this.isRemote = isRemote;
+            this.credentials = credentials;
+            this.repoUrl = repoUrl;           
+        }
+
+        public IRepository Repository { get { return repository; } }
+
+        public bool IsRemote { get { return isRemote; } }
+
+        /// <summary>
+        /// Prepares the git repository for first use.
+        /// </summary>
+        /// <param name="repo"></param>
+        /// <param name="credentials"></param>
+        /// <param name="branchName"></param>
+        /// <param name="url"></param>
+        public void PrepareRemoteRepoForUse(string branchName)
+        {
+            // Normalize (download branches) before using the branch
+            this.NormalizeGitDirectory();
+
+            string targetBranch = branchName;
+            if (string.IsNullOrWhiteSpace(branchName))
+            {
+                targetBranch = Repository.Head.Name;
+            }
+            var branchNameInfo = new GitBranchNameInfo(targetBranch);
+
+            Reference newHead = null;
+            var localReference = GetLocalReference(branchNameInfo);
+            if (localReference != null)
+            {
+                newHead = localReference;
+            }
+
+            if (newHead == null)
+            {
+                var remoteReference = GetRemoteReference(branchNameInfo);
+                if (remoteReference != null)
+                {
+                    Repository.Network.Fetch(repoUrl, new[]
+                            {
+                                string.Format("{0}:{1}", remoteReference.CanonicalName, targetBranch)
+                            });
+
+                    newHead = Repository.Refs[string.Format("refs/heads/{0}", targetBranch)];
+                }
+            }
+
+            if (newHead != null)
+            {
+                logger.WriteLine(string.Format("Switching to branch '{0}'", targetBranch));
+                Repository.Refs.UpdateTarget(Repository.Refs.Head, newHead);
+            }
+        }
+
+        public void CheckoutFilesIfExist(params string[] fileNames)
+        {
+            if (fileNames == null || fileNames.Length == 0)
+            {
+                return;
+            }
+
+            logger.WriteLine(string.Format("Checking out files that might be needed later."));
+
+            foreach (var fileName in fileNames)
+            {
+                try
+                {
+                    logger.WriteLine(string.Format("  Trying to check out '{0}'", fileName));
+
+                    var headBranch = repository.Head;
+                    var tip = headBranch.Tip;
+
+                    var treeEntry = tip[fileName];
+                    if (treeEntry == null)
+                    {
+                        continue;
+                    }
+
+                    var fullPath = Path.Combine(GetRepositoryDirectory(), fileName);
+                    using (var stream = ((Blob)treeEntry.Target).GetContentStream())
+                    {
+                        using (var streamReader = new BinaryReader(stream))
+                        {
+                            File.WriteAllBytes(fullPath, streamReader.ReadBytes((int)stream.Length));
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.WriteLine(string.Format(" An error occurred while checking out '{0}': '{1}'", fileName, ex.Message));
+                }
+            }
+        }
+
+        public string GetRepositoryDirectory(bool omitGitPostFix = true)
+        {
+            var gitDirectory = repository.Info.Path;
+
+            gitDirectory = gitDirectory.TrimEnd('\\');
+
+            if (omitGitPostFix && gitDirectory.EndsWith(".git"))
+            {
+                gitDirectory = gitDirectory.Substring(0, gitDirectory.Length - ".git".Length);
+                gitDirectory = gitDirectory.TrimEnd('\\');
+            }
+
+            return gitDirectory;
+        }
+
+        public Reference GetLocalReference(GitBranchNameInfo branchNameInfo)
+        {
+            var targetBranchName = branchNameInfo.GetCanonicalBranchName();
+            return repository.Refs.FirstOrDefault(localRef => string.Equals(localRef.CanonicalName, targetBranchName));
+        }
+
+        public DirectReference GetRemoteReference(GitBranchNameInfo branchNameInfo)
+        {
+            var targetBranchName = branchNameInfo.GetCanonicalBranchName();
+            var remoteReferences = repository.Network.ListReferences(repoUrl);
+            return remoteReferences.FirstOrDefault(remoteRef => string.Equals(remoteRef.CanonicalName, targetBranchName));
+        }       
+
+        public void Dispose()
+        {
+            if (repository != null)
+            {
+                repository.Dispose();
+                repository = null;
+            }
+        }
+
+        // private helper methods.
+
+        private void NormalizeGitDirectory()
+        {
+            var remote = EnsureSingleRemoteIsDefined();
+            EnsureRepoHasRefSpecs(remote);
+
+            logger.WriteLine(string.Format("Fetching from remote '{0}' using the following refspecs: {1}.",
+                remote.Name, string.Join(", ", remote.FetchRefSpecs.Select(r => r.Specification))));
+
+            var fetchOptions = new FetchOptions();
+            fetchOptions.CredentialsProvider = (url, user, types) => credentials;
+            Repository.Network.Fetch(remote, fetchOptions);
+
+            CreateMissingLocalBranchesFromRemoteTrackingOnes(remote.Name);
+            var headSha = Repository.Refs.Head.TargetIdentifier;
+
+            if (!Repository.Info.IsHeadDetached)
+            {
+                logger.WriteLine(string.Format("HEAD points at branch '{0}'.", headSha));
+                return;
+            }
+
+            logger.WriteLine(string.Format("HEAD is detached and points at commit '{0}'.", headSha));
+
+            // In order to decide whether a fake branch is required or not, first check to see if any local branches have the same commit SHA of the head SHA.
+            // If they do, go ahead and checkout that branch
+            // If no, go ahead and check out a new branch, using the known commit SHA as the pointer
+            var localBranchesWhereCommitShaIsHead = Repository.Branches.Where(b => !b.IsRemote && b.Tip.Sha == headSha).ToList();
+
+            if (localBranchesWhereCommitShaIsHead.Count > 1)
+            {
+                var names = string.Join(", ", localBranchesWhereCommitShaIsHead.Select(r => r.CanonicalName));
+                var message = string.Format("Found more than one local branch pointing at the commit '{0}'. Unable to determine which one to use ({1}).", headSha, names);
+                throw new InvalidOperationException(message);
+            }
+
+            if (localBranchesWhereCommitShaIsHead.Count == 0)
+            {
+                logger.WriteLine(string.Format("No local branch pointing at the commit '{0}'. Fake branch needs to be created.", headSha));
+                CreateFakeBranchPointingAtThePullRequestTip();
+            }
+            else
+            {
+                logger.WriteLine(string.Format("Checking out local branch 'refs/heads/{0}'.", localBranchesWhereCommitShaIsHead[0].Name));
+                Repository.Branches[localBranchesWhereCommitShaIsHead[0].Name].Checkout();
+            }
+        }
+
+        private void CreateFakeBranchPointingAtThePullRequestTip()
+        {
+            var remote = Repository.Network.Remotes.Single();
+
+            var remoteTips = this.GetRemoteTips(remote);
+
+            var headTipSha = Repository.Head.Tip.Sha;
+            var refs = remoteTips.Where(r => r.TargetIdentifier == headTipSha).ToList();
+
+            if (refs.Count == 0)
+            {
+                var message = string.Format("Couldn't find any remote tips from remote '{0}' pointing at the commit '{1}'.", remote.Url, headTipSha);
+                throw new InvalidOperationException(message);
+            }
+
+            if (refs.Count > 1)
+            {
+                var names = string.Join(", ", refs.Select(r => r.CanonicalName));
+                var message = string.Format("Found more than one remote tip from remote '{0}' pointing at the commit '{1}'. Unable to determine which one to use ({2}).", remote.Url, headTipSha, names);
+                throw new InvalidOperationException(message);
+            }
+
+            var canonicalName = refs[0].CanonicalName;
+            logger.WriteLine(string.Format("Found remote tip '{0}' pointing at the commit '{1}'.", canonicalName, headTipSha));
+
+            if (!canonicalName.StartsWith("refs/pull/") && !canonicalName.StartsWith("refs/pull-requests/"))
+            {
+                var message = string.Format("Remote tip '{0}' from remote '{1}' doesn't look like a valid pull request.", canonicalName, remote.Url);
+                throw new InvalidOperationException(message);
+            }
+
+            var fakeBranchName = canonicalName.Replace("refs/pull/", "refs/heads/pull/").Replace("refs/pull-requests/", "refs/heads/pull-requests/");
+
+            logger.WriteLine(string.Format("Creating fake local branch '{0}'.", fakeBranchName));
+            Repository.Refs.Add(fakeBranchName, new ObjectId(headTipSha));
+
+            logger.WriteLine(string.Format("Checking local branch '{0}' out.", fakeBranchName));
+            Repository.Checkout(fakeBranchName);
+        }
+
+        private IEnumerable<DirectReference> GetRemoteTips(Remote remote)
+        {
+            return Repository.Network.ListReferences(remote, (url, fromUrl, types) => credentials);
+        }
+
+        private void CreateMissingLocalBranchesFromRemoteTrackingOnes(string remoteName)
+        {
+            var prefix = string.Format("refs/remotes/{0}/", remoteName);
+            var remoteHeadCanonicalName = string.Format("{0}{1}", prefix, "HEAD");
+
+            foreach (var remoteTrackingReference in Repository.Refs.FromGlob(prefix + "*").Where(r => r.CanonicalName != remoteHeadCanonicalName))
+            {
+                var localCanonicalName = "refs/heads/" + remoteTrackingReference.CanonicalName.Substring(prefix.Length);
+
+                if (Repository.Refs.Any(x => x.CanonicalName == localCanonicalName))
+                {
+                    logger.WriteLine(string.Format("Skipping local branch creation since it already exists '{0}'.", remoteTrackingReference.CanonicalName));
+                    continue;
+                }
+                logger.WriteLine(string.Format("Creating local branch from remote tracking '{0}'.", remoteTrackingReference.CanonicalName));
+
+                var symbolicReference = remoteTrackingReference as SymbolicReference;
+                if (symbolicReference == null)
+                {
+                    Repository.Refs.Add(localCanonicalName, new ObjectId(remoteTrackingReference.TargetIdentifier), true);
+                }
+                else
+                {
+                    Repository.Refs.Add(localCanonicalName, new ObjectId(symbolicReference.ResolveToDirectReference().TargetIdentifier), true);
+                }
+            }
+        }
+
+        private void EnsureRepoHasRefSpecs(Remote remote)
+        {
+            if (remote.FetchRefSpecs.Any(r => r.Source == "refs/heads/*"))
+                return;
+
+            var allBranchesFetchRefSpec = string.Format("+refs/heads/*:refs/remotes/{0}/*", remote.Name);
+            logger.WriteLine(string.Format("Adding refspec: {0}", allBranchesFetchRefSpec));
+            Repository.Network.Remotes.Update(remote, r => r.FetchRefSpecs.Add(allBranchesFetchRefSpec));
+        }
+
+        private Remote EnsureSingleRemoteIsDefined()
+        {
+            var remotes = Repository.Network.Remotes;
+            var howMany = remotes.Count();
+
+            if (howMany == 1)
+            {
+                var remote = remotes.Single();
+                logger.WriteLine(string.Format("One remote found ({0} -> '{1}').", remote.Name, remote.Url));
+                return remote;
+            }
+
+            var message = string.Format("{0} remote(s) have been detected. When being run on a TeamCity agent, the Git repository is expected to bear one (and no more than one) remote.", howMany);
+            throw new InvalidOperationException(message);
+        }
+
+
+    }
+}

--- a/src/GitReleaseNotes/Git/IGitRepositoryContextFactory.cs
+++ b/src/GitReleaseNotes/Git/IGitRepositoryContextFactory.cs
@@ -1,0 +1,14 @@
+﻿using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitReleaseNotes.Git
+{
+    public interface IGitRepositoryContextFactory
+    {
+        GitRepositoryContext GetRepositoryContext();
+    }
+}

--- a/src/GitReleaseNotes/GitReleaseNotes.csproj
+++ b/src/GitReleaseNotes/GitReleaseNotes.csproj
@@ -65,6 +65,11 @@
     <Compile Include="ArgumentVerifier.cs" />
     <Compile Include="BlankLine.cs" />
     <Compile Include="Contributor.cs" />
+    <Compile Include="Git\GitBranchNameInfo.cs" />
+    <Compile Include="Git\GitLocalRepositoryContextFactory.cs" />
+    <Compile Include="Git\GitRemoteRepositoryContextFactory.cs" />
+    <Compile Include="Git\GitRepositoryContext.cs" />
+    <Compile Include="Git\IGitRepositoryContextFactory.cs" />
     <Compile Include="IReleaseNoteLine.cs" />
     <Compile Include="IssueTrackers\BitBucket\BitBucketIssueTracker.cs" />
     <Compile Include="IssueTrackers\BitBucket\IBitBucketApi.cs" />

--- a/src/GitReleaseNotes/GitReleaseNotesArguments.cs
+++ b/src/GitReleaseNotes/GitReleaseNotesArguments.cs
@@ -21,6 +21,18 @@ namespace GitReleaseNotes
         [Description("GitHub access token")]
         public string Token { get; set; }
 
+        [Description("GitHub username")]
+        public string RepoUsername { get; set; }
+
+        [Description("GitHub password")]
+        public string RepoPassword { get; set; }
+
+        [Description("Url of repository")]
+        public string RepoUrl { get; set; }
+
+        [Description("The branch name to checkout any existing release notes file")]
+        public string RepoBranch { get; set; }
+
         [Description("Issue tracker username")]
         public string Username { get; set; }
 

--- a/src/GitReleaseNotes/Program.cs
+++ b/src/GitReleaseNotes/Program.cs
@@ -93,13 +93,19 @@ namespace GitReleaseNotes
                 string outputFile = null;
                 var previousReleaseNotes = new SemanticReleaseNotes();
 
-                var gitRepoPath = gitRepo.Info.Path;
+                var outputPath = gitRepo.Info.Path;
+                var outputDirectory = new DirectoryInfo(outputPath);
+                if (outputDirectory.Name == ".git")
+                {
+                    outputPath = outputDirectory.Parent.FullName;
+                }
+
                 if (!string.IsNullOrEmpty(arguments.OutputFile))
                 {
                     outputFile = Path.IsPathRooted(arguments.OutputFile)
                         ? arguments.OutputFile
-                        : Path.Combine(gitRepoPath, arguments.OutputFile);
-                    previousReleaseNotes = new ReleaseNotesFileReader(fileSystem, gitRepoPath).ReadPreviousReleaseNotes(outputFile);
+                        : Path.Combine(outputPath, arguments.OutputFile);
+                    previousReleaseNotes = new ReleaseNotesFileReader(fileSystem, outputPath).ReadPreviousReleaseNotes(outputFile);
                 }
 
                 var categories = arguments.Categories == null ? Categories : Categories.Concat(arguments.Categories.Split(',')).ToArray();


### PR DESCRIPTION
Took plenty of code from GitVersion (a lot of @GeertvanHorrik's work) and... refactored it a little, to add support for specifying a remote repository.

1. The `GitRepositoryContext` class wraps an IRepository (which it exposes via a property), and stores additional commonly needed state for that repository, such as the authentication credentials, etc. 
2. Took some required `static` helper methods from GitVersion, around preparing a remote repo for use, and refactored them a little to make them instance methods on `GitRepositoryContext`, removing many of the common parameters, in favour of instance state. 

2.  There is a `LocalGitRepositoryContextFactory`, and a `RemoteGitRepositoryContextFactory` - both implementing `IGitRepositoryContextFactory`.

3. `Program.cs` now just resolves the relevant `IGitRepositoryContextFactory` and calls `GetRepositoryContext()` to obtain a `GitRepositoryContext`. It can then access the IRepository instance itself via the `Repository` property of that `GitRepositoryContext`.

4. Added Unit Test coverage.