### PR TITLE
Add /AllLabels argument

### DIFF
--- a/src/GitReleaseNotes.Tests/ReleaseNotesGeneratorTests.cs
+++ b/src/GitReleaseNotes.Tests/ReleaseNotesGeneratorTests.cs
@@ -24,7 +24,7 @@ namespace GitReleaseNotes.Tests
             var currentReleaseInfo = GitRepositoryInfoFinder.GetCurrentReleaseInfo(repo); 
 
             var releaseNotes = ReleaseNotesGenerator.GenerateReleaseNotes(
-                repo, issueTracker, new SemanticReleaseNotes(), new string[0],
+                repo, issueTracker, new SemanticReleaseNotes(), new Categories(),
                 tagToStartFrom, currentReleaseInfo, issueTracker.DiffUrlFormat);
 
             Approvals.Verify(releaseNotes.ToString(), Scrubber);
@@ -45,7 +45,7 @@ namespace GitReleaseNotes.Tests
             var currentReleaseInfo = GitRepositoryInfoFinder.GetCurrentReleaseInfo(repo); 
 
             var releaseNotes = ReleaseNotesGenerator.GenerateReleaseNotes(
-                repo, issueTracker, new SemanticReleaseNotes(), new string[0],
+                repo, issueTracker, new SemanticReleaseNotes(), new Categories(),
                 tagToStartFrom, currentReleaseInfo, string.Empty);
 
             Approvals.Verify(releaseNotes.ToString(), Scrubber);
@@ -86,7 +86,7 @@ Commits:  AC39885536...CA74E870F2
 Commits: E413A880DB...F6924D7A0B");
 
             var releaseNotes = ReleaseNotesGenerator.GenerateReleaseNotes(
-                repo, issueTracker, previousReleaseNotes, new string[0],
+                repo, issueTracker, previousReleaseNotes, new Categories(),
                 tagToStartFrom, currentReleaseInfo, string.Empty);
 
             Approvals.Verify(releaseNotes.ToString(), Scrubber);
@@ -143,7 +143,7 @@ Which spans multiple lines
 Commits: E413A880DB...F6924D7A0B");
 
             var releaseNotes = ReleaseNotesGenerator.GenerateReleaseNotes(
-                repo, issueTracker, previousReleaseNotes, new string[0],
+                repo, issueTracker, previousReleaseNotes, new Categories(),
                 tagToStartFrom, currentReleaseInfo, "url/{0}...{1}");
 
             Approvals.Verify(releaseNotes.ToString(), Scrubber);

--- a/src/GitReleaseNotes.Tests/SemanticReleaseNotesTests.ItemIsCategorisedWithMultipleCategoriesIfAllLabelsIsTrue.approved.txt
+++ b/src/GitReleaseNotes.Tests/SemanticReleaseNotesTests.ItemIsCategorisedWithMultipleCategoriesIfAllLabelsIsTrue.approved.txt
@@ -1,0 +1,3 @@
+﻿ - [#1](http://github.com/org/repo/issues/1) - Issue 1 +feature +enhancement +breaking-change
+
+Commits: 12345678...67890123

--- a/src/GitReleaseNotes.Tests/SemanticReleaseNotesTests.ItemIsNotCategorisedWithMultipleCategoriesIfAllLabelsIsFalse.approved.txt
+++ b/src/GitReleaseNotes.Tests/SemanticReleaseNotesTests.ItemIsNotCategorisedWithMultipleCategoriesIfAllLabelsIsFalse.approved.txt
@@ -1,0 +1,3 @@
+﻿ - [#1](http://github.com/org/repo/issues/1) - Issue 1 +feature
+
+Commits: 12345678...67890123

--- a/src/GitReleaseNotes.Tests/SemanticReleaseNotesTests.cs
+++ b/src/GitReleaseNotes.Tests/SemanticReleaseNotesTests.cs
@@ -22,7 +22,7 @@ namespace GitReleaseNotes.Tests
                     BeginningSha = "12345678",
                     EndSha = "67890123"
                 })
-            }, new string[0]);
+            }, new Categories());
 
             var result = releaseNotes.ToString();
 
@@ -43,7 +43,49 @@ namespace GitReleaseNotes.Tests
                     BeginningSha = "12345678",
                     EndSha = "67890123"
                 })
-            }, new[] { "feature" });
+            }, new Categories(new[] { "feature" }));
+
+            var result = releaseNotes.ToString();
+
+            Approvals.Verify(result);
+        }
+
+        [Fact]
+        public void ItemIsCategorisedWithMultipleCategoriesIfAllLabelsIsTrue()
+        {
+            var releaseNotes = new SemanticReleaseNotes(new[]
+            {
+                new SemanticRelease("", null, new List<IReleaseNoteLine>
+                {
+                    new ReleaseNoteItem("Issue 1", "#1", new Uri("http://github.com/org/repo/issues/1"),
+                        new[] {"feature", "enhancement", "breaking-change"}, DateTimeOffset.Now, new Contributor[0])
+                }, new ReleaseDiffInfo
+                {
+                    BeginningSha = "12345678",
+                    EndSha = "67890123"
+                })
+            }, new Categories("feature", true));
+
+            var result = releaseNotes.ToString();
+
+            Approvals.Verify(result);
+        }
+
+        [Fact]
+        public void ItemIsNotCategorisedWithMultipleCategoriesIfAllLabelsIsFalse()
+        {
+            var releaseNotes = new SemanticReleaseNotes(new[]
+            {
+                new SemanticRelease("", null, new List<IReleaseNoteLine>
+                {
+                    new ReleaseNoteItem("Issue 1", "#1", new Uri("http://github.com/org/repo/issues/1"),
+                        new[] {"feature", "enhancement", "breaking-change"}, DateTimeOffset.Now, new Contributor[0])
+                }, new ReleaseDiffInfo
+                {
+                    BeginningSha = "12345678",
+                    EndSha = "67890123"
+                })
+            }, new Categories("feature", false));
 
             var result = releaseNotes.ToString();
 
@@ -75,7 +117,7 @@ namespace GitReleaseNotes.Tests
                     BeginningSha = "asdsadaf",
                     EndSha = "bfdsadre"
                 })
-            }, new[] { "bug", "enhancement", "feature" });
+            }, new Categories(new[] { "bug", "enhancement", "feature" }));
 
             var result = releaseNotes.ToString();
 
@@ -95,7 +137,7 @@ namespace GitReleaseNotes.Tests
                     BeginningSha = "12345678",
                     EndSha = "67890123"
                 })
-            }, new[] { "bug", "enhancement", "feature" });
+            }, new Categories(new[] { "bug", "enhancement", "feature" }));
 
             var result = releaseNotes.ToString();
 
@@ -116,7 +158,7 @@ namespace GitReleaseNotes.Tests
                     BeginningSha = "12345678",
                     EndSha = "67890123"
                 })
-            }, new[] { "internal refactoring" });
+            }, new Categories(new[] { "internal refactoring" }));
 
             var result = releaseNotes.ToString();
 
@@ -158,9 +200,9 @@ Commits: 1234567...6789012
             readReleaseNotes.Releases[0].DiffInfo.EndSha.ShouldBe("6789012");
             readReleaseNotes.Releases[0].ReleaseName.ShouldBe(null);
             readReleaseNotes.Releases[0].ReleaseNoteLines.Count.ShouldBe(3);
-            readReleaseNotes.Releases[0].ReleaseNoteLines[0].ToString(new string[0]).ShouldBe(" - Issue 1 [#1](http://github.com/org/repo/issues/1)");
-            readReleaseNotes.Releases[0].ReleaseNoteLines[1].ToString(new string[0]).ShouldBe(string.Empty);
-            readReleaseNotes.Releases[0].ReleaseNoteLines[2].ToString(new string[0]).ShouldBe("Note: Some shiz..");
+            readReleaseNotes.Releases[0].ReleaseNoteLines[0].ToString(new Categories()).ShouldBe(" - Issue 1 [#1](http://github.com/org/repo/issues/1)");
+            readReleaseNotes.Releases[0].ReleaseNoteLines[1].ToString(new Categories()).ShouldBe(string.Empty);
+            readReleaseNotes.Releases[0].ReleaseNoteLines[2].ToString(new Categories()).ShouldBe("Note: Some shiz..");
         }
 
         [Fact]

--- a/src/GitReleaseNotes/BlankLine.cs
+++ b/src/GitReleaseNotes/BlankLine.cs
@@ -2,7 +2,7 @@ namespace GitReleaseNotes
 {
     public class BlankLine : IReleaseNoteLine
     {
-        public string ToString(string[] categories)
+        public string ToString(Categories categories)
         {
             return string.Empty;
         }

--- a/src/GitReleaseNotes/Categories.cs
+++ b/src/GitReleaseNotes/Categories.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+
+namespace GitReleaseNotes
+{
+    public sealed class Categories
+    {
+        private static readonly string[] DefaultCategories = { "bug", "enhancement", "feature" };
+
+        public bool AllLabels { get; private set; }
+
+        public string[] AvailableCategories { get; private set; }
+
+        public Categories(string categories, bool allLabels)
+        {
+            AvailableCategories = categories == null ? DefaultCategories : DefaultCategories.Concat(categories.Split(',')).ToArray();
+            AllLabels = allLabels;
+        }
+
+        public Categories(string[] categories, bool allLabels)
+        {
+            AvailableCategories = categories;
+            AllLabels = allLabels;
+        }
+
+        public Categories()
+        {
+            AvailableCategories = new string[0];
+        }
+    }
+}

--- a/src/GitReleaseNotes/GitReleaseNotes.csproj
+++ b/src/GitReleaseNotes/GitReleaseNotes.csproj
@@ -62,6 +62,7 @@
   <ItemGroup>
     <Compile Include="ArgumentVerifier.cs" />
     <Compile Include="BlankLine.cs" />
+    <Compile Include="Categories.cs" />
     <Compile Include="Contributor.cs" />
     <Compile Include="IReleaseNoteLine.cs" />
     <Compile Include="IssueTrackers\BitBucket\BitBucketIssueTracker.cs" />

--- a/src/GitReleaseNotes/GitReleaseNotesArguments.cs
+++ b/src/GitReleaseNotes/GitReleaseNotesArguments.cs
@@ -59,5 +59,9 @@ namespace GitReleaseNotes
 
         [Description("BitBuckets Consumer Secret Key used for Oauth authentication")]
         public string ConsumerSecretKey { get; set; }
+
+        [Description("Specifies that all labels should be included in the release notes, if not specified then only the defaults (bug, enhancement, feature) are included.")]
+        public bool AllLabels { get; set; }
+
     }
 }

--- a/src/GitReleaseNotes/IReleaseNoteLine.cs
+++ b/src/GitReleaseNotes/IReleaseNoteLine.cs
@@ -2,6 +2,6 @@ namespace GitReleaseNotes
 {
     public interface IReleaseNoteLine
     {
-        string ToString(string[] categories);
+        string ToString(Categories categories);
     }
 }

--- a/src/GitReleaseNotes/Program.cs
+++ b/src/GitReleaseNotes/Program.cs
@@ -22,7 +22,6 @@ namespace GitReleaseNotes
 {
     public static class Program
     {
-        private static readonly string[] Categories = { "bug", "enhancement", "feature" };
         private static Dictionary<IssueTracker, IIssueTracker> _issueTrackers;
 
         static int Main(string[] args)
@@ -101,7 +100,7 @@ namespace GitReleaseNotes
                 previousReleaseNotes = new ReleaseNotesFileReader(fileSystem, repositoryRoot).ReadPreviousReleaseNotes(outputFile);
             }
 
-            var categories = arguments.Categories == null ? Categories : Categories.Concat(arguments.Categories.Split(',')).ToArray();
+            var categories = new Categories(arguments.Categories, arguments.AllLabels);
             TaggedCommit tagToStartFrom = arguments.AllTags
                 ? GitRepositoryInfoFinder.GetFirstCommit(gitRepo)
                 : GitRepositoryInfoFinder.GetLastTaggedCommit(gitRepo) ?? GitRepositoryInfoFinder.GetFirstCommit(gitRepo);

--- a/src/GitReleaseNotes/ReleaseNoteItem.cs
+++ b/src/GitReleaseNotes/ReleaseNoteItem.cs
@@ -47,24 +47,41 @@ namespace GitReleaseNotes
             get { return resolvedOn; }
         }
 
-        public Contributor[] Contributors { get { return contributors; }}
+        public Contributor[] Contributors { get { return contributors; } }
 
-        public string ToString(string[] categories)
+        public string ToString(Categories categories)
         {
-            var taggedCategory = Tags.FirstOrDefault(t => categories.Any(c => c.Equals(t, StringComparison.InvariantCultureIgnoreCase)));
-            if ("bug".Equals(taggedCategory, StringComparison.InvariantCultureIgnoreCase))
-                taggedCategory = "fix";
-            var category = taggedCategory == null
-                ? null
-                : String.Format(" +{0}", taggedCategory.Replace(" ", "-"));
+            var formattedcategories = FormatCategories(Tags, categories);
             var issueNum = IssueNumber == null ? null : String.Format(" [{0}]", IssueNumber);
             var url = HtmlUrl == null ? null : String.Format("({0})", HtmlUrl);
             var contributors = Contributors == null || Contributors.Length == 0 ?
                 string.Empty : " contributed by " + String.Join(", ", Contributors.Select(r => String.Format("{0} ([{1}]({2}))", r.Name, r.Username, r.Url)));
-            
-            return string.Format(" - {1}{2}{4}{0}{5}{3}", Title, issueNum, url, category,
+
+            return string.Format(" - {1}{2}{4}{0}{5}{3}", Title, issueNum, url, formattedcategories,
                 Title.TrimStart().StartsWith("-") ? null : " - ",
                 contributors).Replace("  ", " ").Replace("- -", "-");
+        }
+
+        private string FormatCategories(string[] tags, Categories categories)
+        {
+            var taggedCategories = categories.AllLabels ? Tags : new[] { Tags.FirstOrDefault(t => categories.AvailableCategories.Any(c => c.Equals(t, StringComparison.InvariantCultureIgnoreCase))) };
+
+            if(taggedCategories == null || (taggedCategories.Length == 1 && string.IsNullOrEmpty(taggedCategories[0])))
+            {
+                return null;
+            }
+
+            for (int i = 0; i < taggedCategories.Length; i++)
+            {
+                if ("bug".Equals(taggedCategories[i], StringComparison.InvariantCultureIgnoreCase))
+                {
+                    taggedCategories[i] = "fix";
+                }
+                taggedCategories[i] = string.Concat(" +", taggedCategories[i].Replace(" ", "-"));
+            }
+
+            return string.Join(string.Empty, taggedCategories);
+
         }
     }
 }

--- a/src/GitReleaseNotes/ReleaseNoteLine.cs
+++ b/src/GitReleaseNotes/ReleaseNoteLine.cs
@@ -9,7 +9,7 @@ namespace GitReleaseNotes
             this.line = line;
         }
 
-        public string ToString(string[] categories)
+        public string ToString(Categories categories)
         {
             return line;
         }

--- a/src/GitReleaseNotes/ReleaseNotesGenerator.cs
+++ b/src/GitReleaseNotes/ReleaseNotesGenerator.cs
@@ -10,7 +10,7 @@ namespace GitReleaseNotes
     {
         public static SemanticReleaseNotes GenerateReleaseNotes(
             IRepository gitRepo, IIssueTracker issueTracker, SemanticReleaseNotes previousReleaseNotes, 
-            string[] categories, TaggedCommit tagToStartFrom, ReleaseInfo currentReleaseInfo, 
+            Categories categories, TaggedCommit tagToStartFrom, ReleaseInfo currentReleaseInfo, 
             string diffUrlFormat)
         {
             var releases = ReleaseFinder.FindReleases(gitRepo, tagToStartFrom, currentReleaseInfo);

--- a/src/GitReleaseNotes/SemanticReleaseNotes.cs
+++ b/src/GitReleaseNotes/SemanticReleaseNotes.cs
@@ -12,16 +12,16 @@ namespace GitReleaseNotes
         //readonly Regex _issueRegex = new Regex(" - (?<Issue>.*?)(?<IssueLink> \\[(?<IssueId>.*?)\\]\\((?<IssueUrl>.*?)\\))*( *\\+(?<Tag>[^ \\+]*))*", RegexOptions.Compiled);
         static readonly Regex ReleaseRegex = new Regex("# (?<Title>.*?)( \\((?<Date>.*?)\\))?$", RegexOptions.Compiled);
         static readonly Regex LinkRegex = new Regex(@"\[(?<Text>.*?)\]\((?<Link>.*?)\)$", RegexOptions.Compiled);
-        readonly string[] categories;
+        readonly Categories categories;
         readonly SemanticRelease[] releases;
 
         public SemanticReleaseNotes()
         {
-            categories = new string[0];
+            categories = new Categories();
             releases = new SemanticRelease[0];
         }
 
-        public SemanticReleaseNotes(IEnumerable<SemanticRelease> releaseNoteItems, string[] categories)
+        public SemanticReleaseNotes(IEnumerable<SemanticRelease> releaseNoteItems, Categories categories)
         {
             this.categories = categories;
             releases = releaseNoteItems.ToArray();
@@ -180,7 +180,7 @@ namespace GitReleaseNotes
                 }
             }
 
-            return new SemanticReleaseNotes(releases, new string[0]);
+            return new SemanticReleaseNotes(releases, new Categories());
         }
 
         public SemanticReleaseNotes Merge(SemanticReleaseNotes previousReleaseNotes)
@@ -208,8 +208,8 @@ namespace GitReleaseNotes
                     semanticRelease.ReleaseNoteLines.AddRange(releaseFromPrevious.ReleaseNoteLines);
                 }
             }
-
-            return new SemanticReleaseNotes(mergedReleases, categories.Union(previousReleaseNotes.categories).Distinct().ToArray());
+            
+            return new SemanticReleaseNotes(mergedReleases, new Categories(categories.AvailableCategories.Union(previousReleaseNotes.categories.AvailableCategories).Distinct().ToArray(), categories.AllLabels));
         }
 
         private static SemanticRelease CreateMergedSemanticRelease(SemanticRelease r)


### PR DESCRIPTION
Fix #69
If /AllLabels is used, all labels (tags) are used as categories on the release notes.