### PR TITLE
Updates for BitBucket release note generation.

### DIFF
--- a/src/GitReleaseNotes.Tests/GitReleaseNotes.Tests.csproj
+++ b/src/GitReleaseNotes.Tests/GitReleaseNotes.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0-beta1-build1051\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0-beta1-build1051\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\packages\LibGit2Sharp.0.20.2.0\build\net40\LibGit2Sharp.props" Condition="Exists('..\packages\LibGit2Sharp.0.20.2.0\build\net40\LibGit2Sharp.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -12,7 +13,7 @@
     <AssemblyName>GitReleaseNotes.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>090cc19e</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>fcff4def</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,6 +44,10 @@
     </Reference>
     <Reference Include="LibGit2Sharp">
       <HintPath>..\packages\LibGit2Sharp.0.20.2.0\lib\net40\LibGit2Sharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1-beta1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NSubstitute">
       <HintPath>..\packages\NSubstitute.1.8.1.0\lib\net45\NSubstitute.dll</HintPath>
@@ -103,6 +108,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\LibGit2Sharp.0.20.2.0\build\net40\LibGit2Sharp.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.0.20.2.0\build\net40\LibGit2Sharp.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0-beta1-build1051\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0-beta1-build1051\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/GitReleaseNotes.Tests/SemanticReleaseNotesTests.cs
+++ b/src/GitReleaseNotes.Tests/SemanticReleaseNotesTests.cs
@@ -43,7 +43,7 @@ namespace GitReleaseNotes.Tests
                     BeginningSha = "12345678",
                     EndSha = "67890123"
                 })
-            }, new Categories(new[] { "feature" }));
+            }, new Categories(new[] { "feature" }, true));
 
             var result = releaseNotes.ToString();
 
@@ -117,7 +117,7 @@ namespace GitReleaseNotes.Tests
                     BeginningSha = "asdsadaf",
                     EndSha = "bfdsadre"
                 })
-            }, new Categories(new[] { "bug", "enhancement", "feature" }));
+            }, new Categories(new[] { "bug", "enhancement", "feature" }, true));
 
             var result = releaseNotes.ToString();
 
@@ -137,7 +137,7 @@ namespace GitReleaseNotes.Tests
                     BeginningSha = "12345678",
                     EndSha = "67890123"
                 })
-            }, new Categories(new[] { "bug", "enhancement", "feature" }));
+            }, new Categories(new[] { "bug", "enhancement", "feature" }, true));
 
             var result = releaseNotes.ToString();
 
@@ -158,7 +158,7 @@ namespace GitReleaseNotes.Tests
                     BeginningSha = "12345678",
                     EndSha = "67890123"
                 })
-            }, new Categories(new[] { "internal refactoring" }));
+            }, new Categories(new[] { "internal refactoring" }, true));
 
             var result = releaseNotes.ToString();
 

--- a/src/GitReleaseNotes.Tests/packages.config
+++ b/src/GitReleaseNotes.Tests/packages.config
@@ -3,9 +3,11 @@
   <package id="ApprovalTests" version="3.0.8" targetFramework="net45" />
   <package id="ApprovalUtilities" version="3.0.8" targetFramework="net45" />
   <package id="LibGit2Sharp" version="0.20.2.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1-beta1" targetFramework="net45" />
   <package id="NSubstitute" version="1.8.1.0" targetFramework="net45" />
   <package id="Octokit" version="0.6.2" targetFramework="net45" />
   <package id="Shouldly" version="2.2.1" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0-beta1-build1051" targetFramework="net45" />
 </packages>

--- a/src/GitReleaseNotes/GitReleaseNotes.csproj
+++ b/src/GitReleaseNotes/GitReleaseNotes.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0-beta1-build1051\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0-beta1-build1051\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\packages\LibGit2Sharp.0.20.2.0\build\net40\LibGit2Sharp.props" Condition="Exists('..\packages\LibGit2Sharp.0.20.2.0\build\net40\LibGit2Sharp.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -13,7 +14,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <NuGetPackageImportStamp>9ab793cc</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>df0ac670</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -41,6 +42,10 @@
     </Reference>
     <Reference Include="LibGit2Sharp">
       <HintPath>..\packages\LibGit2Sharp.0.20.2.0\lib\net40\LibGit2Sharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1-beta1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Octokit">
       <HintPath>..\packages\Octokit.0.6.2\lib\net45\Octokit.dll</HintPath>
@@ -120,6 +125,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Fody.1.26.4\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.26.4\build\Fody.targets'))" />
     <Error Condition="!Exists('..\packages\LibGit2Sharp.0.20.2.0\build\net40\LibGit2Sharp.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.0.20.2.0\build\net40\LibGit2Sharp.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0-beta1-build1051\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0-beta1-build1051\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <UsingTask TaskName="CosturaCleanup" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll" TaskFactory="CodeTaskFactory">
     <ParameterGroup>
@@ -158,6 +164,10 @@ foreach (var item in filesToCleanup)
     <CosturaCleanup Config="FodyWeavers.xml" Files="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename)%(Extension)')" />
   </Target>
   <Import Project="..\packages\Fody.1.26.4\build\Fody.targets" Condition="Exists('..\packages\Fody.1.26.4\build\Fody.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/GitReleaseNotes/IssueTrackers/BitBucket/BitBucketApi.cs
+++ b/src/GitReleaseNotes/IssueTrackers/BitBucket/BitBucketApi.cs
@@ -6,9 +6,12 @@ using RestSharp;
 
 namespace GitReleaseNotes.IssueTrackers.BitBucket
 {
+    using Newtonsoft.Json;
+
     public class BitBucketApi : IBitBucketApi
     {
-        private const string IssueClosed = "resolved";
+        private const string IssueClosed = "closed";
+        private const string IssueResolved = "resolved";
         private const string ApiUrl = "https://bitbucket.org/api/1.0/";
 
         public IEnumerable<OnlineIssue> GetClosedIssues(GitReleaseNotesArguments arguments, DateTimeOffset? since, string accountName, string repoSlug, bool oauth)
@@ -30,12 +33,13 @@ namespace GitReleaseNotes.IssueTrackers.BitBucket
             {
                 throw new Exception("Failed to query BitBucket: " + response.StatusDescription);
             }
-            dynamic responseObject = SimpleJson.DeserializeObject(response.Content);
+            dynamic responseObject = JsonConvert.DeserializeObject<dynamic>(response.Content);
+            
             var issues = new List<OnlineIssue>();
             foreach (var issue in responseObject.issues)
             {
-                DateTimeOffset lastChange = DateTimeOffset.Parse(issue.utc_last_updated);
-                if (issue.status != IssueClosed || lastChange <= since)
+                DateTimeOffset lastChange = DateTimeOffset.Parse(issue.utc_last_updated.ToString());
+                if ((issue.status != IssueClosed && issue.status != IssueResolved) || lastChange <= since)
                 {
                     continue;
                 }
@@ -64,8 +68,8 @@ namespace GitReleaseNotes.IssueTrackers.BitBucket
 
         private static void GenerateOauthRequest(GitReleaseNotesArguments arguments, Uri baseUrl, string MethodLocation, RestRequest request)
         {
-            var consumerKey = arguments.Username;
-            var consumerSecret = arguments.Password;
+            var consumerKey = string.IsNullOrEmpty(arguments.Username) ? arguments.ConsumerKey : arguments.Username;
+            var consumerSecret = string.IsNullOrEmpty(arguments.Password) ? arguments.ConsumerSecretKey : arguments.Password;
             var oAuth = new OAuthBase();
             var nonce = oAuth.GenerateNonce();
             var timeStamp = oAuth.GenerateTimeStamp();

--- a/src/GitReleaseNotes/packages.config
+++ b/src/GitReleaseNotes/packages.config
@@ -5,6 +5,8 @@
   <package id="Fody" version="1.26.4" targetFramework="net45" developmentDependency="true" />
   <package id="GitHubFlowVersion" version="1.3.2" targetFramework="net45" />
   <package id="LibGit2Sharp" version="0.20.2.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1-beta1" targetFramework="net45" />
   <package id="Octokit" version="0.6.2" targetFramework="net45" />
   <package id="RestSharp" version="105.0.1" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0-beta1-build1051" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Based on issues I experienced using BitBucket (see issue : #71) I have applied the following fixes:

* Fixed unit tests to use the string, bool overload  for the Categories creation so that the solution compiled
* Added xunit runner nuget package to run the unit tests in Visual Studio 2013
* SimpleJson.DeserializeObject to dynamic does not work, I used JsonConvert.DeserializeObject (from [http://www.newtonsoft.com/json](http://www.newtonsoft.com/json)) instead. This was done in order to keep the use of the dynamic object from the API json response. I'm not sure when this changed, but RestSharp needs a line of code uncommented to use dynamic in SimpleJson (see the comment on line 28 from [https://github.com/restsharp/RestSharp/blob/master/RestSharp/SimpleJson.cs](https://github.com/restsharp/RestSharp/blob/master/RestSharp/SimpleJson.cs)).
* Added IssueResolved constant and checked for both closed and resolved issues to add to the Release Notes
* Used arguments.ConsumerKey and  arguments.ConsumerSecretKey if arguments.Username  or arguments.Password are not supplied for OAth. This may be overkill as the keys need to be supplied for OAuth and not the User and password. Please review this and let me know if this should be changed to use only the keys and not username and password as these do not authenticate correctly using the API in any case as far as I could tell.

These changes now enable BitBucket Release notes using the /ConsumerKey and /ConsumerSecretKey switches.